### PR TITLE
Allow to use non-string subject and key

### DIFF
--- a/lib/ratelimit.rb
+++ b/lib/ratelimit.rb
@@ -28,7 +28,7 @@ class Ratelimit
   # @param [String] subject A unique key to identify the subject. For example, 'user@foo.com'
   def add(subject)
     bucket = get_bucket
-    subject = @key + ":" + subject
+    subject = "#{@key}:#{subject}"
     redis.multi do
       redis.hincrby(subject, bucket, 1)
       redis.hdel(subject, (bucket + 1) % @bucket_count)
@@ -45,7 +45,7 @@ class Ratelimit
     bucket = get_bucket
     interval = [interval, @bucket_interval].max
     count = (interval / @bucket_interval).floor
-    subject = @key + ":" + subject
+    subject = "#{@key}:#{subject}"
     counts = redis.multi do
       redis.hget(subject, bucket)
       count.downto(1) do

--- a/test/test_ratelimit.rb
+++ b/test/test_ratelimit.rb
@@ -17,6 +17,16 @@ class TestRatelimit < Test::Unit::TestCase
     end
   end
 
+  should "be able to add to the count for a non-string subject" do
+    @r.add(123)
+    @r.add(123)
+    assert_equal 2, @r.count(123, 1)
+    assert_equal 0, @r.count(124, 1)
+    Timecop.travel(10) do
+      assert_equal 0, @r.count(123, 1)
+    end
+  end
+
   should "respond to exceeded? method correctly" do
     5.times do
       @r.add("value1")


### PR DESCRIPTION
Sometimes it's convenient to use as subject some record id, which is number.
