### PR TITLE
fix issue with wrong count on bucket_span == count(..interval)

### DIFF
--- a/lib/ratelimit.rb
+++ b/lib/ratelimit.rb
@@ -56,8 +56,8 @@ class Ratelimit
     count = (interval / @bucket_interval).floor
     subject = "#{@key}:#{subject}"
 
-    keys = (0..count).map do |i|
-      (bucket - i + @bucket_count) % @bucket_count
+    keys = (0..count - 1).map do |i|
+      (bucket - i) % @bucket_count
     end
     return redis.hmget(subject, *keys).inject(0) {|a, i| a + i.to_i}
   end

--- a/spec/ratelimit_spec.rb
+++ b/spec/ratelimit_spec.rb
@@ -92,4 +92,12 @@ describe Ratelimit do
     end
     expect(@value).to be 1
   end
+
+
+  it "counts correclty if bucket_span equals count-interval  " do
+    @r = Ratelimit.new("key", {:bucket_span => 10, bucket_interval: 1})
+    @r.add('value1')
+    expect(@r.count('value1', 10)).to eql(1)
+  end
+
 end


### PR DESCRIPTION
- add spec for the edge-case
- remove unneeded operation in ring-key calc (x + y % y == x % y)
