### PR TITLE
Wrap options[:redis] in redis-namespace

### DIFF
--- a/lib/ratelimit.rb
+++ b/lib/ratelimit.rb
@@ -29,7 +29,7 @@ class Ratelimit
     if @bucket_count < 3
       raise ArgumentError.new("Cannot have less than 3 buckets")
     end
-    @redis = options[:redis]
+    @raw_redis = options[:redis]
   end
 
   # Add to the counter for a given subject.
@@ -114,6 +114,6 @@ class Ratelimit
   end
 
   def redis
-    @redis ||= Redis::Namespace.new(:ratelimit, :redis => @redis || Redis.new)
+    @redis ||= Redis::Namespace.new(:ratelimit, redis: @raw_redis || Redis.new)
   end
 end

--- a/spec/ratelimit_spec.rb
+++ b/spec/ratelimit_spec.rb
@@ -1,6 +1,24 @@
 require 'spec_helper'
 
 describe Ratelimit do
+  describe '.initialize' do
+    subject { described_class.new(key, options) }
+
+    let(:options) { Hash.new }
+
+    context 'with key' do
+      let(:key) { 'key' }
+
+      context 'with redis option' do
+        let(:redis) { double('redis') }
+        let(:options) { super().merge(redis: redis) }
+
+        it 'wraps redis in redis-namespace' do
+          expect(subject.send(:redis)).to be_instance_of(Redis::Namespace)
+        end
+      end
+    end
+  end
 
   before do
     @r = Ratelimit.new("key")


### PR DESCRIPTION
Is the original intent to wrap `options[:redis]` in `redis-namespace`? If so, this pull requests addresses that requirement.