### PR TITLE
Fix potential race condition in #add

### DIFF
--- a/lib/ratelimit.rb
+++ b/lib/ratelimit.rb
@@ -41,7 +41,7 @@ class Ratelimit
   def add(subject, count = 1)
     bucket = get_bucket
     subject = "#{@key}:#{subject}"
-    redis.pipelined do
+    redis.multi do
       redis.hincrby(subject, bucket, count)
       redis.hdel(subject, (bucket + 1) % @bucket_count)
       redis.hdel(subject, (bucket + 2) % @bucket_count)

--- a/spec/ratelimit_spec.rb
+++ b/spec/ratelimit_spec.rb
@@ -75,7 +75,7 @@ describe Ratelimit do
     expect(@r.within_bounds?("value1", {:threshold => 10, :interval => 30})).to be false
   end
 
-  it "accept a threshhold and a block that gets executed once it's below the threshold" do
+  it "accept a threshold and a block that gets executed once it's below the threshold" do
     expect(@r.count("key", 30)).to eq(0)
     31.times do
       @r.add("key")
@@ -100,7 +100,7 @@ describe Ratelimit do
   end
 
 
-  it "counts correclty if bucket_span equals count-interval  " do
+  it "counts correctly if bucket_span equals count-interval  " do
     @r = Ratelimit.new("key", {:bucket_span => 10, bucket_interval: 1})
     @r.add('value1')
     expect(@r.count('value1', 10)).to eql(1)


### PR DESCRIPTION
When incrementing the counter, we should use `Redis#multi`, rather than `Redis#pipeline`, to ensure that the `hincrby`, `hdel`, and `expire` are in the same call. If another process is checking `#count` between when `hincrby` and `expire` are called it could lead to an invalid count. `Redis#multi` protects against that.

See the [first example for rate limiting](http://redis.io/commands/INCR#pattern-rate-limiter-2) in the Redis documentation for `INCR`. Also note that the JS code that this was inspired by [used the `multi/exec` pattern](https://github.com/chriso/redback/blob/32fb4fc323d58142a5492f472bc4ca82fc2e326c/lib/advanced_structures/RateLimit.js#L87-L100) as well.