### PR TITLE
Fix counting the same buckets multiple times when the interval > bucket_span

### DIFF
--- a/lib/ratelimit.rb
+++ b/lib/ratelimit.rb
@@ -55,7 +55,7 @@ class Ratelimit
   # @param [Integer] interval How far back (in seconds) to retrieve activity.
   def count(subject, interval)
     bucket = get_bucket
-    interval = [interval, @bucket_interval].max
+    interval = [[interval, @bucket_interval].max, @bucket_span].min
     count = (interval / @bucket_interval).floor
     subject = "#{@key}:#{subject}"
 

--- a/spec/ratelimit_spec.rb
+++ b/spec/ratelimit_spec.rb
@@ -124,4 +124,9 @@ describe Ratelimit do
     expect(@r.count('value1', 10)).to eql(1)
   end
 
+  it "counts correctly if interval is greater than bucket_span" do
+    @r = Ratelimit.new("key", { bucket_span: 10, bucket_interval: 1})
+    @r.add('value1')
+    expect(@r.count('value1', 40)).to eql(1)
+  end
 end


### PR DESCRIPTION
I ran into a problem where `count` was returning multiples of what was expected, and discovered it was due to the interval being given to count being greater than what was expected when setting up the bucket. In this case, the same buckets were being pulled repeatedly, hence the multiple.

Please let me know if I'm misunderstanding anything!