### PR TITLE
Implement threadsafe version of exec_within_threshold

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'mlanett-redis-lock', require: 'redis-lock'
 # Specify your gem's dependencies in ratelimit.gemspec
 gemspec
 


### PR DESCRIPTION
When using exec_within_threshold in an environment with multiple threads/processes you can run into an issue where multiple threads read the count for a given subject at the same time.  If the read count is right below the current threshold then all threads will be allowed to execute before any of them can perform an add that pushes the count over the threshold.

For example, if you had three threads and a ratelimit with a threshold of 20 in 600 seconds and the current count was at 19.  All three threads would read the current count of 19 and the exceeded? check used in exec_within_threshold would evaluate to false so all three threads would execute the block.  

The fix requires a lock.  Instead of implementing a lock from scratch I used an already existing implementation by mlanett.  Each thread must acquire the lock before it can read the count and releases the lock after incrementing the count.  This ensure that the threshold is never exceeded.

I wrote some tests to verify the issue and that this fixes it in a work project where we use the ratelimit gem.  

The test that exposes the issue where exec_within_threshold allows more than the threshold number of executions in an interval is here:
`
      rlKey = SecureRandom.uuid
      rlSubject = SecureRandom.uuid
      ratelimit = Ratelimit.new(rlKey,{:redis => $redis})
    
      statusMap = { stop: 0, sleep: 0, run: 0, finished: 0}

      # the sleep is not required to get the bug to happen but it doesn't happen 100% of the time without it
      # and we don't want randomly failing tests
      threads = [
        Thread.new { ratelimit.exec_within_threshold(rlSubject, {interval: 10, threshold: 1 }) { sleep 0.5; ratelimit.add(rlSubject) }},
        Thread.new { ratelimit.exec_within_threshold(rlSubject, {interval: 10, threshold: 1 }) { sleep 0.5; ratelimit.add(rlSubject) }},
        Thread.new { ratelimit.exec_within_threshold(rlSubject, {interval: 10, threshold: 1 }) { sleep 0.5; ratelimit.add(rlSubject) }},
        Thread.new { ratelimit.exec_within_threshold(rlSubject, {interval: 10, threshold: 1 }) { sleep 0.5; ratelimit.add(rlSubject) }},
        Thread.new { ratelimit.exec_within_threshold(rlSubject, {interval: 10, threshold: 1 }) { sleep 0.5; ratelimit.add(rlSubject) }},
        Thread.new { ratelimit.exec_within_threshold(rlSubject, {interval: 10, threshold: 1 }) { sleep 0.5; ratelimit.add(rlSubject) }},
        Thread.new { ratelimit.exec_within_threshold(rlSubject, {interval: 10, threshold: 1 }) { sleep 0.5; ratelimit.add(rlSubject) }}
      ]

      sleep 1

      threads.each do |t| 
        status_symbol = t.status ? t.status.to_sym : :finished
        statusMap[status_symbol] += 1
      end
      
      expect(statusMap[:finished]).to be > 1
`

The test with the fixed implementation looks like this:

`
rlKey = SecureRandom.uuid
      rlSubject = SecureRandom.uuid
      ratelimit = Ratelimit.new(rlKey, {:redis => $redis})
      
      statusMap = { stop: 0, sleep: 0, run: 0, finished: 0}
      threads = [
        Thread.new { ratelimit.exec_and_increment_within_threshold(rlSubject, {interval: 10, threshold: 1 })},
        Thread.new { ratelimit.exec_and_increment_within_threshold(rlSubject, {interval: 10, threshold: 1 })},
        Thread.new { ratelimit.exec_and_increment_within_threshold(rlSubject, {interval: 10, threshold: 1 })},
        Thread.new { ratelimit.exec_and_increment_within_threshold(rlSubject, {interval: 10, threshold: 1 })},
        Thread.new { ratelimit.exec_and_increment_within_threshold(rlSubject, {interval: 10, threshold: 1 })},
        Thread.new { ratelimit.exec_and_increment_within_threshold(rlSubject, {interval: 10, threshold: 1 })},
        Thread.new { ratelimit.exec_and_increment_within_threshold(rlSubject, {interval: 10, threshold: 1 })}
      ]

     sleep 1

      threads.each do |t| 
        status_symbol = t.status ? t.status.to_sym : :finished
        statusMap[status_symbol] += 1
      end

      expect(statusMap[:finished]).to eq(1)
`