### PR TITLE
Deprecate calling commands on `Redis` inside `Redis#multi`

### DIFF
--- a/lib/ratelimit.rb
+++ b/lib/ratelimit.rb
@@ -41,11 +41,11 @@ class Ratelimit
   def add(subject, count = 1)
     bucket = get_bucket
     subject = "#{@key}:#{subject}"
-    redis.multi do
-      redis.hincrby(subject, bucket, count)
-      redis.hdel(subject, (bucket + 1) % @bucket_count)
-      redis.hdel(subject, (bucket + 2) % @bucket_count)
-      redis.expire(subject, @bucket_expiry)
+    redis.multi do |transaction|
+      transaction.hincrby(subject, bucket, count)
+      transaction.hdel(subject, (bucket + 1) % @bucket_count)
+      transaction.hdel(subject, (bucket + 2) % @bucket_count)
+      transaction.expire(subject, @bucket_expiry)
     end.first
   end
 


### PR DESCRIPTION
> * Deprecate calling commands on `Redis` inside `Redis#multi`. See #1059.
>   ```ruby
>   redis.multi do
>     redis.get("key")
>   end
>   ```
> 
>   should be replaced by:
> 
>   ```ruby
>   redis.multi do |transaction|
>     transaction.get("key")
>   end
>   ```
>
> https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#460
