### PR TITLE
Remove redis deprecation warning

### DIFF
--- a/lib/ratelimit.rb
+++ b/lib/ratelimit.rb
@@ -41,11 +41,11 @@ class Ratelimit
   def add(subject, count = 1)
     bucket = get_bucket
     subject = "#{@key}:#{subject}"
-    redis.multi do
-      redis.hincrby(subject, bucket, count)
-      redis.hdel(subject, (bucket + 1) % @bucket_count)
-      redis.hdel(subject, (bucket + 2) % @bucket_count)
-      redis.expire(subject, @bucket_expiry)
+    redis.multi do |transaction|
+      transaction.hincrby(subject, bucket, count)
+      transaction.hdel(subject, (bucket + 1) % @bucket_count)
+      transaction.hdel(subject, (bucket + 2) % @bucket_count)
+      transaction.expire(subject, @bucket_expiry)
     end.first
   end
 

--- a/ratelimit.gemspec
+++ b/ratelimit.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency             "redis", ">= 2.0.0"
+  spec.add_dependency             "redis", ">= 3.0.0"
   spec.add_dependency             "redis-namespace", ">= 1.0.0"
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", ">= 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "fakeredis"
   spec.add_development_dependency "timecop"


### PR DESCRIPTION
Fix #40 

Switch to new multi syntax in `#add` call.

See https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#460

This syntax was introduced in 3.0.0 and the old style will be deprecated
in 5.0.0.