### PR TITLE
Use absolute bucket numbers instead of a wrapping set of buckets

### DIFF
--- a/ratelimit.gemspec
+++ b/ratelimit.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency             "redis-namespace", ">= 1.0.0"
   spec.add_development_dependency "bundler", ">= 1.6"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "fakeredis"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "yard"

--- a/spec/ratelimit_spec.rb
+++ b/spec/ratelimit_spec.rb
@@ -14,6 +14,7 @@ describe Ratelimit do
         let(:options) { super().merge(redis: redis) }
 
         it 'wraps redis in redis-namespace' do
+          expect(redis).to receive(:script).with(:load, anything).twice
           expect(subject.send(:redis)).to be_instance_of(Redis::Namespace)
         end
       end
@@ -116,7 +117,6 @@ describe Ratelimit do
     end
     expect(@value).to be 1
   end
-
 
   it "counts correctly if bucket_span equals count-interval  " do
     @r = Ratelimit.new("key", {:bucket_span => 10, bucket_interval: 1})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,6 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'coveralls'
 Coveralls.wear!
-require 'fakeredis'
 require 'timecop'
 require 'ratelimit'
 


### PR DESCRIPTION
This fixes #45 and improves performance by calculcating the count for subjects in redis by lua scripts without transferring the values of the buckets

An additional maintenance call is necessary to cleanup old keys in a subjects hash. If the subject is not accessed for a longer time it will still be removed by the existing expiration.